### PR TITLE
Update package version number.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = gias3
-version = 3.0.0
+version = 3.0.1
 description = Geometry Image-Analysis Statistics version 3 (GIAS3)
 long_description = file: README.rst
 keywords = musculoskeletal, modelling


### PR DESCRIPTION
The primary reason for this PR is that PyPI doesn't allow re-uploads of package versions. To be able to update the description on the GIAS3 PyPI page we must release a new version.